### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Further runs will be immediate, as the image will be cached locally.
 The recommended way to run this container looks like this:
 
 ```bash
-$ docker run -d -p 80:80 -v /home/user/articles.json:/data/db.json clue/json-server
+$ docker run -d -p 80:80 -v /home/user/data/:/data/ clue/json-server
 ```
+
+where /home/user/data directory contains db.json file.
+
 
 The above example exposes the JSON Server REST API on port 80, so that you can now browse to:
 


### PR DESCRIPTION
Docker does not allow to "move" file as part of the rename procedure as it shown in exception for what ever reasons json-server needs to do it. 
It  throws exception:

```
/usr/local/lib/node_modules/json-server/node_modules/lowdb/src/disk.js:14
      if (err) throw err
               ^
Error: EBUSY: resource busy or locked, rename '/data/.~db.json' -> '/data/db.json'
    at Error (native)
```

However when docker mounts directory from a host to container then any files within directory can be "moved".
