### PR TITLE
Add environment variable to set the db.json file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ VOLUME /data
 
 EXPOSE 80
 ADD run.sh /run.sh
-ENTRYPOINT ["bash", "/run.sh"]
-CMD []
+CMD bash /run.sh

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ args="$@"
 
 args="$@ -p 80"
 
-file=$DB_PATH
+file=${DB_PATH:-'/data/db.json'}
 
 if [ -f $file ]; then
     echo "Found $file, trying to open"

--- a/run.sh
+++ b/run.sh
@@ -4,10 +4,12 @@ args="$@"
 
 args="$@ -p 80"
 
-file=/data/db.json
+echo "DB path used $DB_PATH"
+file=$DB_PATH
+
 if [ -f $file ]; then
-    echo "Found db.json, trying to open"
-    args="$args db.json"
+    echo "Found $file, trying to open"
+    args="$args $file"
 fi
 
 file=/data/file.js

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,6 @@ args="$@"
 
 args="$@ -p 80"
 
-echo "DB path used $DB_PATH"
 file=$DB_PATH
 
 if [ -f $file ]; then


### PR DESCRIPTION
While using this json server image on [drone ci](http://readme.drone.io/usage/overview/) I had the necessity of passing the db.json without using volumes.

Given that, I created this PR make it possible to use both environment:

```
docker run -p 80:80 "DB_PATH=/path/to/my/db.json" clue/json-server
```

and volumes:

```
docker run -d -p 80:80 -v /home/user/articles.json:/data/db.json clue/json-server
```
