### PR TITLE
convert image to node:alpine and shell to ash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:alpine
 MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN npm install -g json-server
@@ -8,5 +8,5 @@ VOLUME /data
 
 EXPOSE 80
 ADD run.sh /run.sh
-ENTRYPOINT ["bash", "/run.sh"]
+ENTRYPOINT ["ash", "/run.sh"]
 CMD []

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 args="$@"
 


### PR DESCRIPTION
By using node:alpine for the image instead of node:latest, it reduced the size of the image from 685 megs to 78 megs.  

bash is not included with alpine.  ash is the included shell in alpine